### PR TITLE
Fix: deselecting events

### DIFF
--- a/src/event-selection/EventSelection.tsx
+++ b/src/event-selection/EventSelection.tsx
@@ -9,9 +9,10 @@ export function EventSelection() {
 
   const select = (show: boolean) =>
     setEvents?.((events) => {
-    const newEvents: Record<string, Wcj.Event> = {};
+      const newEvents: Record<string, Wcj.Event> = {};
 
       for (const eventId in events) {
+        newEvents[eventId] = events[eventId];
         newEvents[eventId].showInCalendar = show;
       }
 


### PR DESCRIPTION
This fixes the test which is failing on CI.

The error when running the test was:

    TypeError: Cannot set properties of undefined (setting 'showInCalendar')

This was because `newEvents[eventId]` was undefined, so we couldn't set
values on it. Presumably `newEvents` is intended to be a copy of the
existing events, but with just the `showInCalendar` value changed.

I tried setting `events` as the initial value of `newEvents`, but that
didn't actually end up hiding the event (and I'm not sure why), so
duplicating and updating each record one by one is the next best thing
(and actually works).

Ideally we could just `map` over the list of `events` but that only
works on arrays (?) and converting `events` to an array (and later back
to an object) seems like way more hassle than it's worth - particularly
if events are indexed starting at 1 rather than 0.